### PR TITLE
Fix circular user response

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -5,10 +5,14 @@ import { Usuario } from 'src/usuarios/entities/usuario.entity';
 import { IsPublic } from 'src/shared/decorators/is-public.decorator';
 import { ApiPaginatedResponse } from 'src/shared/decorators/api-paginated-response.decorator';
 import { LocalAuthGuard } from './guards/local-auth.guard';
+import { UsuariosService } from 'src/usuarios/usuarios.service';
 
 @Controller('auth')
 export class AuthController {
-  constructor(private readonly authService: AuthService) {}
+  constructor(
+    private readonly authService: AuthService,
+    private readonly usuariosService: UsuariosService,
+  ) {}
 
   @IsPublic()
   @Post('login')
@@ -22,6 +26,6 @@ export class AuthController {
   @ApiPaginatedResponse(Usuario)
   @Get('me')
   me(@CurrentUser() usuario: Usuario){
-    return usuario;
+    return this.usuariosService.entityToResponseDto(usuario);
   }
 }

--- a/src/usuarios/usuarios.service.ts
+++ b/src/usuarios/usuarios.service.ts
@@ -46,7 +46,7 @@ export class UsuariosService {
     return this.entityToResponseDto(usuario);
   }
 
-  private entityToResponseDto(usuario: Usuario): UsuarioResponseDto {
+  public entityToResponseDto(usuario: Usuario): UsuarioResponseDto {
     return {
       id: usuario.id,
       nomeCompleto: usuario.nomeCompleto,


### PR DESCRIPTION
## Summary
- convert the private `entityToResponseDto` helper to a public method
- map the current user response in `AuthController.me` so it returns a DTO

## Testing
- `npm run build` *(fails: `nest` not found)*
- `npm test` *(fails: `jest` not found)*


------
https://chatgpt.com/codex/tasks/task_e_68658f3dcde0832ab6ed559d07f5fc91