### PR TITLE
Implement profile image upload

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,16 @@
 import { NestFactory } from '@nestjs/core';
+import { NestExpressApplication } from '@nestjs/platform-express';
+import { join } from 'path';
+import * as express from 'express';
 import { AppModule } from './app.module';
 import { MailModule } from './mail/mail.module'; // Importe o MailModule
 import { MailService } from './mail/mail.service';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create<NestExpressApplication>(AppModule);
+
+  // Servir arquivos estáticos da pasta ImagemPerfil
+  app.use('/ImagemPerfil', express.static(join(__dirname, '..', 'ImagemPerfil')));
   
   // Obtenha a instância do MailService
   const mailService = app.select(MailModule).get(MailService);


### PR DESCRIPTION
## Summary
- support serving static files from `ImagemPerfil`
- add profile image upload to user create and update
- store uploaded photos in `ImagemPerfil` folder

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867df217a948333b30ca6313d662142