### PR TITLE
Fix missing interceptor import

### DIFF
--- a/src/usuarios/usuarios.controller.ts
+++ b/src/usuarios/usuarios.controller.ts
@@ -9,6 +9,7 @@ import {
   Delete,
   Query,
   UseGuards,
+  UseInterceptors,
 } from "@nestjs/common";
 import { FileInterceptor } from '@nestjs/platform-express';
 import { memoryStorage } from 'multer';


### PR DESCRIPTION
## Summary
- import `UseInterceptors` in usuarios controller

## Testing
- `npm run build` *(fails: Type 'null' is not assignable to type 'string')*
- `npm test` *(fails to run due to TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_6867e1fb56c08333a8e62c4d1a769377