### PR TITLE
Modularize file storage

### DIFF
--- a/src/documentos/documentos.module.ts
+++ b/src/documentos/documentos.module.ts
@@ -3,10 +3,12 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Documento } from './entities/documento.entity';
 import { DocumentosService } from './documentos.service';
 import { DocumentosController } from './documentos.controller';
+import { FilesModule } from '../files/files.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Documento]),
+    FilesModule,
   ],
   providers: [DocumentosService],
   controllers: [DocumentosController],

--- a/src/documentos/documentos.service.ts
+++ b/src/documentos/documentos.service.ts
@@ -1,40 +1,25 @@
-// src/documentos/documentos.service.ts
-import { Injectable, BadRequestException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Documento } from './entities/documento.entity';
-import * as fs from 'fs';
-import * as path from 'path';
 import { Requerimento } from '../requerimentos/entities/requerimento.entity';
+import { FilesService } from '../files/files.service';
 
 @Injectable()
 export class DocumentosService {
-  private uploadDir = path.resolve(__dirname, '../../uploads');
-
   constructor(
     @InjectRepository(Documento)
     private readonly repo: Repository<Documento>,
-  ) {
-    if (!fs.existsSync(this.uploadDir)) {
-      fs.mkdirSync(this.uploadDir, { recursive: true });
-    }
-  }
+    private readonly filesService: FilesService,
+  ) {}
 
   async create(requerimentoId: number, file: Express.Multer.File): Promise<Documento> {
-    if (!file) {
-      throw new BadRequestException('Arquivo não enviado');
-    }
+    const filename = await this.filesService.save(file);
 
-    const timestamp = Date.now();
-    const filename = `${timestamp}-${file.originalname}`;
-    const destino = path.join(this.uploadDir, filename);
-    await fs.promises.writeFile(destino, file.buffer);
-
-    // Aqui passamos o objeto parcial de Requerimento
-   const doc = this.repo.create({
-    caminho: filename,
-    requerimento: { id: requerimentoId } as Requerimento,
-  });
-  return this.repo.save(doc);
-    }
+    const doc = this.repo.create({
+      caminho: filename,
+      requerimento: { id: requerimentoId } as Requerimento,
+    });
+    return this.repo.save(doc);
+  }
 }

--- a/src/files/files.module.ts
+++ b/src/files/files.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { FilesService } from './files.service';
+
+@Module({
+  providers: [FilesService],
+  exports: [FilesService],
+})
+export class FilesModule {}

--- a/src/files/files.service.ts
+++ b/src/files/files.service.ts
@@ -1,0 +1,33 @@
+import { Injectable, BadRequestException } from '@nestjs/common';
+import * as path from 'path';
+import * as fs from 'fs';
+
+@Injectable()
+export class FilesService {
+  private readonly uploadDir = path.resolve(__dirname, '../../uploads');
+
+  constructor() {
+    if (!fs.existsSync(this.uploadDir)) {
+      fs.mkdirSync(this.uploadDir, { recursive: true });
+    }
+  }
+
+  async save(file: Express.Multer.File, subfolder = ''): Promise<string> {
+    if (!file) {
+      throw new BadRequestException('Arquivo não enviado');
+    }
+
+    const timestamp = Date.now();
+    const filename = `${timestamp}-${file.originalname}`;
+
+    const targetDir = subfolder
+      ? path.join(this.uploadDir, subfolder)
+      : this.uploadDir;
+
+    await fs.promises.mkdir(targetDir, { recursive: true });
+    const destination = path.join(targetDir, filename);
+    await fs.promises.writeFile(destination, file.buffer);
+
+    return subfolder ? path.join(subfolder, filename) : filename;
+  }
+}

--- a/src/usuarios/usuarios.controller.ts
+++ b/src/usuarios/usuarios.controller.ts
@@ -11,6 +11,8 @@ import {
   ParseIntPipe,
   HttpException,
   HttpStatus,
+  UseInterceptors,
+  UploadedFile,
 } from "@nestjs/common";
 import { UsuariosService } from "./usuarios.service";
 import { CreateUsuarioDto } from "./dto/create-usuario.dto";
@@ -23,6 +25,8 @@ import { Role } from "src/enums/role.enum";
 import { IsPublic } from "src/shared/decorators/is-public.decorator";
 import { CurrentUser } from "src/shared/decorators/current-user.decorator";
 import { Usuario } from "./entities/usuario.entity";
+import { FileInterceptor } from '@nestjs/platform-express';
+import { memoryStorage } from 'multer';
 
 @UseGuards(RolesGuard)
 @Controller("usuarios")
@@ -92,6 +96,21 @@ export class UsuariosController {
   ) {
     await this.usuariosService.update(+id, updateUsuarioDto);
     return { message: "Usuário atualizado com sucesso." };
+  }
+
+  @Patch(":id/foto")
+  @UseInterceptors(
+    FileInterceptor('foto', {
+      storage: memoryStorage(),
+      limits: { fileSize: 10 * 1024 * 1024 },
+    }),
+  )
+  async uploadFoto(
+    @Param('id', ParseIntPipe) id: number,
+    @UploadedFile() file: Express.Multer.File,
+  ) {
+    await this.usuariosService.uploadFoto(id, file);
+    return { message: 'Foto atualizada com sucesso.' };
   }
 
   @Delete(":id")

--- a/src/usuarios/usuarios.module.ts
+++ b/src/usuarios/usuarios.module.ts
@@ -6,6 +6,7 @@ import { Usuario, Medico, Enfermeiro } from "./entities/usuario.entity";
 import { Requerimento } from "src/requerimentos/entities/requerimento.entity";
 import { RequerimentosModule } from "src/requerimentos/requerimentos.module";
 import { MailModule } from 'src/mail/mail.module';
+import { FilesModule } from '../files/files.module';
 
 
 @Module({
@@ -14,7 +15,8 @@ import { MailModule } from 'src/mail/mail.module';
   imports: [
     TypeOrmModule.forFeature([Usuario, Medico, Enfermeiro]),
     forwardRef(() => RequerimentosModule),
-  MailModule
+    MailModule,
+    FilesModule,
   ],
   exports: [TypeOrmModule, UsuariosService],
 })


### PR DESCRIPTION
## Summary
- add `FilesService` and module to handle uploads
- refactor `DocumentosService` to use shared service
- support uploading a user photo
- wire up `FilesModule` in user and document modules

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686823f29f0c832a80fb69b54d8c2cdc