### PR TITLE
Sanitize filenames on upload

### DIFF
--- a/src/documentos/documentos.service.spec.ts
+++ b/src/documentos/documentos.service.spec.ts
@@ -1,12 +1,23 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { DocumentosService } from './documentos.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Documento } from './entities/documento.entity';
+import * as fs from 'fs';
+
+jest.mock('src/enums/etapa.enum', () => ({}), { virtual: true });
 
 describe('DocumentosService', () => {
   let service: DocumentosService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [DocumentosService],
+      providers: [
+        DocumentosService,
+        {
+          provide: getRepositoryToken(Documento),
+          useValue: { create: jest.fn(), save: jest.fn() },
+        },
+      ],
     }).compile();
 
     service = module.get<DocumentosService>(DocumentosService);
@@ -14,5 +25,22 @@ describe('DocumentosService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  it('sanitizes filenames to stay inside upload directory', async () => {
+    const writeSpy = jest.spyOn(fs.promises, 'writeFile').mockResolvedValue();
+
+    const file = {
+      originalname: '../escape.txt',
+      buffer: Buffer.from('data'),
+    } as Express.Multer.File;
+
+    await service.create(1, file);
+
+    const dest = writeSpy.mock.calls[0][0] as string;
+    expect(dest.startsWith(service['uploadDir'])).toBe(true);
+    expect(dest).not.toContain('..');
+
+    writeSpy.mockRestore();
   });
 });

--- a/src/documentos/documentos.service.ts
+++ b/src/documentos/documentos.service.ts
@@ -26,7 +26,8 @@ export class DocumentosService {
     }
 
     const timestamp = Date.now();
-    const filename = `${timestamp}-${file.originalname}`;
+    const safeName = path.basename(file.originalname);
+    const filename = `${timestamp}-${safeName}`;
     const destino = path.join(this.uploadDir, filename);
     await fs.promises.writeFile(destino, file.buffer);
 


### PR DESCRIPTION
## Summary
- sanitize uploaded filenames with `path.basename`
- add a test ensuring filenames cannot escape the uploads directory

## Testing
- `npx jest src/documentos/documentos.service.spec.ts --runInBand --verbose`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68683b1c76a0832a8f47cdc3930ebc64