### PR TITLE
feat(files): add reusable storage service

### DIFF
--- a/src/documentos/documentos.controller.spec.ts
+++ b/src/documentos/documentos.controller.spec.ts
@@ -1,5 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { DocumentosController } from './documentos.controller';
+import { DocumentosService } from './documentos.service';
+import { FileStorageService } from '../shared/services/file-storage.service';
 
 describe('DocumentosController', () => {
   let controller: DocumentosController;
@@ -7,6 +9,7 @@ describe('DocumentosController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [DocumentosController],
+      providers: [DocumentosService, FileStorageService],
     }).compile();
 
     controller = module.get<DocumentosController>(DocumentosController);

--- a/src/documentos/documentos.module.ts
+++ b/src/documentos/documentos.module.ts
@@ -3,13 +3,16 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Documento } from './entities/documento.entity';
 import { DocumentosService } from './documentos.service';
 import { DocumentosController } from './documentos.controller';
+import { FileStorageService } from '../shared/services/file-storage.service';
+import { SharedModule } from '../shared/shared.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Documento]),
+    SharedModule,
   ],
-  providers: [DocumentosService],
+  providers: [DocumentosService, FileStorageService],
   controllers: [DocumentosController],
-  exports: [DocumentosService],
+  exports: [DocumentosService, FileStorageService],
 })
 export class DocumentosModule {}

--- a/src/documentos/documentos.service.spec.ts
+++ b/src/documentos/documentos.service.spec.ts
@@ -1,12 +1,13 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { DocumentosService } from './documentos.service';
+import { FileStorageService } from '../shared/services/file-storage.service';
 
 describe('DocumentosService', () => {
   let service: DocumentosService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [DocumentosService],
+      providers: [DocumentosService, FileStorageService],
     }).compile();
 
     service = module.get<DocumentosService>(DocumentosService);

--- a/src/documentos/documentos.service.ts
+++ b/src/documentos/documentos.service.ts
@@ -3,9 +3,9 @@ import { Injectable, BadRequestException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Documento } from './entities/documento.entity';
-import * as fs from 'fs';
 import * as path from 'path';
 import { Requerimento } from '../requerimentos/entities/requerimento.entity';
+import { FileStorageService } from '../shared/services/file-storage.service';
 
 @Injectable()
 export class DocumentosService {
@@ -14,10 +14,8 @@ export class DocumentosService {
   constructor(
     @InjectRepository(Documento)
     private readonly repo: Repository<Documento>,
+    private readonly fileStorage: FileStorageService,
   ) {
-    if (!fs.existsSync(this.uploadDir)) {
-      fs.mkdirSync(this.uploadDir, { recursive: true });
-    }
   }
 
   async create(requerimentoId: number, file: Express.Multer.File): Promise<Documento> {
@@ -27,14 +25,12 @@ export class DocumentosService {
 
     const timestamp = Date.now();
     const filename = `${timestamp}-${file.originalname}`;
-    const destino = path.join(this.uploadDir, filename);
-    await fs.promises.writeFile(destino, file.buffer);
+    await this.fileStorage.saveFile(this.uploadDir, filename, file.buffer);
 
-    // Aqui passamos o objeto parcial de Requerimento
-   const doc = this.repo.create({
-    caminho: filename,
-    requerimento: { id: requerimentoId } as Requerimento,
-  });
-  return this.repo.save(doc);
-    }
+    const doc = this.repo.create({
+      caminho: filename,
+      requerimento: { id: requerimentoId } as Requerimento,
+    });
+    return this.repo.save(doc);
+  }
 }

--- a/src/shared/services/file-storage.service.ts
+++ b/src/shared/services/file-storage.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@nestjs/common';
+import * as fs from 'fs';
+import * as path from 'path';
+
+@Injectable()
+export class FileStorageService {
+  async saveFile(directory: string, filename: string, data: Buffer): Promise<string> {
+    const dir = path.resolve(directory);
+    await fs.promises.mkdir(dir, { recursive: true });
+    const destination = path.join(dir, filename);
+    await fs.promises.writeFile(destination, data);
+    return destination;
+  }
+}

--- a/src/shared/shared.module.ts
+++ b/src/shared/shared.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { FileStorageService } from './services/file-storage.service';
+
+@Module({
+  providers: [FileStorageService],
+  exports: [FileStorageService],
+})
+export class SharedModule {}


### PR DESCRIPTION
## Summary
- modularize file upload logic into `FileStorageService`
- expose the new service via `SharedModule`
- use `FileStorageService` from `DocumentosService`
- update tests and module metadata

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686836bbac2c832aac4aad86b25af3ad