### PR TITLE
Implement photo upload endpoint

### DIFF
--- a/src/documentos/documentos.service.ts
+++ b/src/documentos/documentos.service.ts
@@ -3,7 +3,6 @@ import { Injectable, BadRequestException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Documento } from './entities/documento.entity';
-import * as fs from 'fs';
 import * as path from 'path';
 import { Requerimento } from '../requerimentos/entities/requerimento.entity';
 import { FileStorageService } from '../shared/services/file-storage.service';
@@ -27,8 +26,7 @@ export class DocumentosService {
     const timestamp = Date.now();
     const safeName = path.basename(file.originalname);
     const filename = `${timestamp}-${safeName}`;
-    const destino = path.join(this.uploadDir, filename);
-    await fs.promises.writeFile(destino, file.buffer);
+    await this.fileStorage.saveFile(this.uploadDir, filename, file.buffer);
 
     const doc = this.repo.create({
       caminho: filename,

--- a/src/usuarios/usuarios.module.ts
+++ b/src/usuarios/usuarios.module.ts
@@ -6,6 +6,7 @@ import { Usuario, Medico, Enfermeiro } from "./entities/usuario.entity";
 import { Requerimento } from "src/requerimentos/entities/requerimento.entity";
 import { RequerimentosModule } from "src/requerimentos/requerimentos.module";
 import { MailModule } from 'src/mail/mail.module';
+import { SharedModule } from '../shared/shared.module';
 
 
 @Module({
@@ -14,7 +15,8 @@ import { MailModule } from 'src/mail/mail.module';
   imports: [
     TypeOrmModule.forFeature([Usuario, Medico, Enfermeiro]),
     forwardRef(() => RequerimentosModule),
-  MailModule
+    MailModule,
+    SharedModule,
   ],
   exports: [TypeOrmModule, UsuariosService],
 })


### PR DESCRIPTION
## Summary
- accept only JSON body for user creation
- add photo upload endpoint
- store uploaded user photo via new salvarFoto service method
- reuse FileStorageService for document uploads

## Testing
- `npm test` *(fails: Cannot find module 'src/enums/etapa.enum')*

------
https://chatgpt.com/codex/tasks/task_e_686bd85f62d0832abacf0f7917e2f6ef